### PR TITLE
Editorial: Recover the variable "url"

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
         <p>
           The steps to <dfn>validate a URL-based payment method
           identifier</dfn> are given by the following algorithm. The algorithm
-          takes a <a data-cite="!URL#concept-url">URL</a> as
+          takes a <a data-cite="!URL#concept-url">URL</a> <var>url</var> as
           input and returns true if the URL is valid:
         </p>
         <ol class="algorithm">


### PR DESCRIPTION
- Fixed spec name to sync with linked doc